### PR TITLE
Hacked includes to try to work around a build failure on Trusty

### DIFF
--- a/tesserpy.cpp
+++ b/tesserpy.cpp
@@ -6,6 +6,7 @@
 #include <Python.h>
 #include <structmember.h>
 #include <tesseract/baseapi.h>
+#include <tesseract/strngs.h>
 #include <numpy/arrayobject.h>
 #include "compat.hpp"
 


### PR DESCRIPTION
When I tried to pip2.7 install tesserpy on Ubuntu Trusty, with libtesserpy-dev installed, I got this error:

```
tesserpy.cpp:632:9: error: aggregate ‘STRING value’ has incomplete type and cannot be defined
  STRING value;
         ^
```

The attached PR gets rid of that error, and tesserpy seems to install properly (though I don't know enough about the library to test it properly...)
